### PR TITLE
add underscore to a punctuation pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const PATTERNS = {
   whitespace: /^\s+$/,
   cjk: /[\u4E00-\u9FFF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF\u30A0-\u30FF\u2E80-\u2EFF\u31C0-\u31EF\u3200-\u32FF\u3300-\u33FF\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uD7B0-\uD7FF]/,
   numeric: /^\d+(?:[.,]\d+)*$/,
-  punctuation: /[.,!?;(){}[\]<>:/\\|@#$%^&*+=`~-]/,
+  punctuation: /[.,_!?;(){}[\]<>:/\\|@#$%^&*+=`~-]/,
   alphanumeric: /^[a-zA-Z0-9\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]+$/,
 } as const
 


### PR DESCRIPTION
Currently, when the input (segment) string contains underscores (`_`), the tokenizer incorrectly falls back to [getCharacterCount](https://github.com/johannschopplich/tokenx/blob/6b7a4629c54aaf9c350bc6ceafdec90bfb383201/src/index.ts#L202), treating each character as a separate token.

**Example:**
Input:

```
lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod
```

* **Before fix:** `69 tokens` (equal to character count)
* **After fix:** `24 tokens`
* **For comparison:**

  * Claude: `26 tokens`
  * OpenAI: `25 tokens`